### PR TITLE
Pass flowId value for correctly TC work

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -9,28 +9,28 @@ var getTestName = require('./utils').getTestName;
 module.exports = function(gemini, options) {
     gemini.on('startRunner', function(runner) {
         runner.on('beginState', function(data) {
-            tsm.testStarted({ name: getTestName(data) });
+            tsm.testStarted({ name: getTestName(data), flowId: data.sessionId });
         });
 
         runner.on('skipState', function(data) {
-            tsm.testIgnored({ name: getTestName(data) });
+            tsm.testIgnored({ name: getTestName(data), flowId: data.sessionId });
         });
 
-        runner.on('error', function(errorData) {
-            var testName = getTestName(errorData);
+        runner.on('error', function(data) {
+            var testName = getTestName(data);
 
-            tsm.testFailed({ name: testName, message: errorData.message, details: errorData.stack });
-            tsm.testFinished({ name: testName });
+            tsm.testFailed({ name: testName, message: data.message, details: data.stack, flowId: data.sessionId });
+            tsm.testFinished({ name: testName, flowId: data.sessionId });
         });
 
         runner.on('endTest', function(data) {
             var testName = getTestName(data);
 
             if(data.equal !== true) {
-                tsm.testFailed({ name: testName });
+                tsm.testFailed({ name: testName, flowId: data.sessionId });
             }
 
-            tsm.testFinished({ name: testName });
+            tsm.testFinished({ name: testName, flowId: data.sessionId });
         });
     });
 };

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -20,11 +20,13 @@ describe('gemini-teamcity', function() {
             state: {
                 name: 'State name'
             },
-            browserId: 'Firefox'
+            browserId: 'Firefox',
+            sessionId: 'sessionId'
         };
 
         messageName = {
-            name: 'Suite_full_name.State_name.Firefox'
+            name: 'Suite_full_name.State_name.Firefox',
+            flowId: 'sessionId'
         };
 
         plugin(gemini);


### PR DESCRIPTION
Because of asynchronous run tests TC incorrectly counts the number of tests passed.
So we need to add flowId equal to session id for resolving this problem

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saulis/gemini-teamcity/5)

<!-- Reviewable:end -->
