### PR TITLE
 Report images as test metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ Set the configuration to your `.gemini.yml`
 plugins:
   teamcity: true
 ```
+
+## Options
+
+### imagesDir
+
+Directory to save images to. `gemini-images` by default.
+
+```
+plugins:
+  teamcity:
+    imagesDir: path/to/my/dir
+```

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -13,7 +13,8 @@ module.exports = function(gemini, options) {
     var finishedTests = [];
 
     gemini.on('startRunner', function(runner) {
-        var imagesBase = fs.mkdtempSync('gemini-')
+        var imagesBase = 'gemini-images';
+        fs.mkdirSync(imagesBase);
 
         runner.on('beginState', function(data) {
             tsm.testStarted({ name: utils.getTestName(data), flowId: data.sessionId });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -30,13 +30,13 @@ module.exports = function(gemini, options) {
             var testName = utils.getTestName(data);
 
             var refPath = utils.getImagePath(imagesDir, data, 'Reference');
-            fs.copy(data.refImg.path, refPath).then(function() {
+            fs.copy(data.referencePath || data.refImg.path, refPath).then(function() {
                 utils.reportScreenshot(testName, refPath);
             });
 
             if(data.equal !== true) {
                 var currPath = utils.getImagePath(imagesDir, data, 'Current');
-                fs.copy(data.currImg.path, currPath).then(function() {
+                fs.copy(data.currentPath || data.currImg.path, currPath).then(function() {
                     utils.reportScreenshot(testName, currPath);
                 });
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -11,10 +11,10 @@ var _ = require('lodash');
  */
 module.exports = function(gemini, options) {
     var finishedTests = [];
+    var imagesDir = options && options.imagesDir || 'gemini-images';
 
     gemini.on('startRunner', function(runner) {
-        var imagesBase = 'gemini-images';
-        fs.mkdirSync(imagesBase);
+        fs.ensureDirSync(imagesDir);
 
         runner.on('beginState', function(data) {
             tsm.testStarted({ name: utils.getTestName(data), flowId: data.sessionId });
@@ -29,18 +29,18 @@ module.exports = function(gemini, options) {
         runner.on('testResult', function(data) {
             var testName = utils.getTestName(data);
 
-            var refPath = utils.getImagePath(imagesBase, data, 'Reference');
+            var refPath = utils.getImagePath(imagesDir, data, 'Reference');
             fs.copy(data.refImg.path, refPath).then(function() {
                 utils.reportScreenshot(testName, refPath);
             });
 
             if(data.equal !== true) {
-                var currPath = utils.getImagePath(imagesBase, data, 'Current');
+                var currPath = utils.getImagePath(imagesDir, data, 'Current');
                 fs.copy(data.currImg.path, currPath).then(function() {
                     utils.reportScreenshot(testName, currPath);
                 });
 
-                var diffPath = utils.getImagePath(imagesBase, data, 'Diff');
+                var diffPath = utils.getImagePath(imagesDir, data, 'Diff');
                 data.saveDiffTo(diffPath).then(function() {
                     utils.reportScreenshot(testName, diffPath);
                 });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,5 +1,7 @@
+var path = require('path');
+var fs = require('fs-extra');
 var tsm = require('teamcity-service-messages');
-var getTestName = require('./utils').getTestName;
+var utils  = require('./utils');
 var _ = require('lodash');
 
 /**
@@ -11,20 +13,37 @@ module.exports = function(gemini, options) {
     var finishedTests = [];
 
     gemini.on('startRunner', function(runner) {
+        var imagesBase = fs.mkdtempSync('gemini-')
+
         runner.on('beginState', function(data) {
-            tsm.testStarted({ name: getTestName(data), flowId: data.sessionId });
+            tsm.testStarted({ name: utils.getTestName(data), flowId: data.sessionId });
         });
 
         runner.on('skipState', function(data) {
-            var testName = getTestName(data);
+            var testName = utils.getTestName(data);
             tsm.testIgnored({ name: testName, flowId: data.sessionId });
             finishedTests.push(testName);
         });
 
         runner.on('testResult', function(data) {
-            var testName = getTestName(data);
+            var testName = utils.getTestName(data);
+
+            var refPath = utils.getImagePath(imagesBase, data, 'Reference');
+            fs.copy(data.refImg.path, refPath).then(function() {
+                utils.reportScreenshot(refPath);
+            });
 
             if(data.equal !== true) {
+                var currPath = utils.getImagePath(imagesBase, data, 'Current');
+                fs.copy(data.currImg.path, currPath).then(function() {
+                    utils.reportScreenshot(currPath);
+                });
+
+                var diffPath = utils.getImagePath(imagesBase, data, 'Diff');
+                data.saveDiffTo(diffPath).then(function() {
+                    utils.reportScreenshot(diffPath);
+                });
+
                 tsm.testFailed({ name: testName, flowId: data.sessionId });
             }
 
@@ -40,7 +59,7 @@ module.exports = function(gemini, options) {
             }
 
             function failTest_(data, testName) {
-                testName = testName || getTestName(data);
+                testName = testName || utils.getTestName(data);
 
                 tsm.testFailed({ name: testName, message: data.message, details: data.stack, flowId: data.sessionId });
                 tsm.testFinished({ name: testName, flowId: data.sessionId });
@@ -48,7 +67,7 @@ module.exports = function(gemini, options) {
 
             function failAllSuiteTests_(data) {
                 data.suite.states.forEach(function(state) {
-                    var testName = getTestName(data, state);
+                    var testName = utils.getTestName(data, state);
                     if (!_.includes(finishedTests, testName)) {
                         failTest_(data, testName);
                     }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -30,18 +30,18 @@ module.exports = function(gemini, options) {
 
             var refPath = utils.getImagePath(imagesBase, data, 'Reference');
             fs.copy(data.refImg.path, refPath).then(function() {
-                utils.reportScreenshot(refPath);
+                utils.reportScreenshot(testName, refPath);
             });
 
             if(data.equal !== true) {
                 var currPath = utils.getImagePath(imagesBase, data, 'Current');
                 fs.copy(data.currImg.path, currPath).then(function() {
-                    utils.reportScreenshot(currPath);
+                    utils.reportScreenshot(testName, currPath);
                 });
 
                 var diffPath = utils.getImagePath(imagesBase, data, 'Diff');
                 data.saveDiffTo(diffPath).then(function() {
-                    utils.reportScreenshot(diffPath);
+                    utils.reportScreenshot(testName, diffPath);
                 });
 
                 tsm.testFailed({ name: testName, flowId: data.sessionId });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,11 +20,12 @@ module.exports = {
           type + '.png'
         );
     },
-    reportScreenshot: function(imagePath) {
+    reportScreenshot: function(testName, imagePath) {
         tsm.publishArtifacts({
             path: imagePath + ' => ' + TEAMCITY_HIDDEN_ARTIFACTS_PATH
         });
         var message = new tsm.Message('testMetadata', {
+            testName: testName,
             type: 'image',
             value: path.join(
               TEAMCITY_HIDDEN_ARTIFACTS_PATH,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,6 +30,7 @@ module.exports = {
         var message = new tsm.Message('testMetadata', {
             testName: testName,
             type: 'image',
+            name: path.basename(imagePath, '.png'),
             value: path.join(
               TEAMCITY_HIDDEN_ARTIFACTS_PATH,
               imagePath

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,7 +27,7 @@ module.exports = {
               path.dirname(imagePath)
             )
         );
-        var message = new tsm.Message('testMetadata', {
+        tsm.testMetadata({
             testName: testName,
             type: 'image',
             value: path.join(
@@ -35,6 +35,5 @@ module.exports = {
               imagePath
             )
         });
-        console.log(message.toString());
     }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,12 +21,12 @@ module.exports = {
         );
     },
     reportScreenshot: function(testName, imagePath) {
-        tsm.publishArtifacts({
-            path: path.resolve(imagePath) + ' => ' + path.join(
+        tsm.publishArtifacts(
+            path.resolve(imagePath) + ' => ' + path.join(
               TEAMCITY_HIDDEN_ARTIFACTS_PATH,
               path.dirname(imagePath)
             )
-        });
+        );
         var message = new tsm.Message('testMetadata', {
             testName: testName,
             type: 'image',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,10 @@ module.exports = {
     },
     reportScreenshot: function(testName, imagePath) {
         tsm.publishArtifacts({
-            path: imagePath + ' => ' + TEAMCITY_HIDDEN_ARTIFACTS_PATH
+            path: path.resolve(imagePath) + ' => ' + path.join(
+              TEAMCITY_HIDDEN_ARTIFACTS_PATH,
+              path.dirname(imagePath)
+            )
         });
         var message = new tsm.Message('testMetadata', {
             testName: testName,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,7 +30,6 @@ module.exports = {
         var message = new tsm.Message('testMetadata', {
             testName: testName,
             type: 'image',
-            name: path.basename(imagePath, '.png'),
             value: path.join(
               TEAMCITY_HIDDEN_ARTIFACTS_PATH,
               imagePath

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,8 @@
+var path = require('path');
+var tsm = require('teamcity-service-messages');
+
+var TEAMCITY_HIDDEN_ARTIFACTS_PATH = '.teamcity'
+
 module.exports = {
     getTestName: function(testData, state) {
         return [
@@ -5,5 +10,27 @@ module.exports = {
             (state || testData.state).name.trim(),
             testData.browserId.replace(/ /g, '')
         ].join('.').replace(/ /g, '_');
+    },
+    getImagePath: function(base, testData, type) {
+        return path.join(
+          base,
+          testData.suite.fullName.trim(),
+          testData.state.name.trim(),
+          testData.browserId.trim(),
+          type + '.png'
+        );
+    },
+    reportScreenshot: function(imagePath) {
+        tsm.publishArtifacts({
+            path: imagePath + ' => ' + TEAMCITY_HIDDEN_ARTIFACTS_PATH
+        });
+        var message = new tsm.Message('testMetadata', {
+            type: 'image',
+            value: path.join(
+              TEAMCITY_HIDDEN_ARTIFACTS_PATH,
+              imagePath
+            )
+        });
+        console.log(message.toString());
     }
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "dependencies": {
     "fs-extra": "^7.0.1",
     "lodash": "^4.0.0",
-    "teamcity-service-messages": "^0.1.7"
+    "teamcity-service-messages": "^0.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "sinon": "^1.14.1"
   },
   "dependencies": {
-    "teamcity-service-messages": "^0.1.7",
-    "lodash": "^4.0.0"
+    "fs-extra": "^7.0.1",
+    "lodash": "^4.0.0",
+    "teamcity-service-messages": "^0.1.7"
   }
 }

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -116,6 +116,7 @@ describe('gemini-teamcity', function() {
             );
             assert.calledWithMatch(
               utils.reportScreenshot,
+              'Suite_default_full_name.State_default_name.default-browser',
               'gemini-0/Suite default full name/State default name/default-browser/Reference.png'
             );
         });
@@ -141,6 +142,7 @@ describe('gemini-teamcity', function() {
                 );
                 assert.calledWithMatch(
                   utils.reportScreenshot,
+                  'Suite_default_full_name.State_default_name.default-browser',
                   'gemini-0/Suite default full name/State default name/default-browser/Reference.png'
                 );
             });
@@ -155,6 +157,7 @@ describe('gemini-teamcity', function() {
                 );
                 assert.calledWithMatch(
                   utils.reportScreenshot,
+                  'Suite_default_full_name.State_default_name.default-browser',
                   'gemini-0/Suite default full name/State default name/default-browser/Current.png'
                 );
             });
@@ -168,6 +171,7 @@ describe('gemini-teamcity', function() {
                 );
                 assert.calledWithMatch(
                   utils.reportScreenshot,
+                  'Suite_default_full_name.State_default_name.default-browser',
                   'gemini-0/Suite default full name/State default name/default-browser/Diff.png'
                 );
             });

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -251,6 +251,35 @@ describe('gemini-teamcity', function() {
             });
         });
     });
+
+    describe("older gemini versions", () => {
+       it("should get reference image in legacy format", () => {
+           runner.emit('testResult', stubEventData_({
+               refImg: null,
+               referencePath: 'referencePath'
+           }));
+
+           assert.calledWithMatch(
+             fs.copy,
+             'referencePath',
+             'gemini-images/Suite default full name/State default name/default-browser/Reference.png'
+           );
+       })
+
+       it("should get current image in legacy format", () => {
+           runner.emit('testResult', stubEventData_({
+               equal: false,
+               currImg: null,
+               currentPath: 'currentPath'
+           }));
+
+           assert.calledWithMatch(
+             fs.copy,
+             'currentPath',
+             'gemini-images/Suite default full name/State default name/default-browser/Current.png'
+           );
+       })
+    });
 });
 
 describe('options', function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -144,7 +144,6 @@ describe('reportScreenshot', function() {
         assert.calledWithMatch(tsm.Message, 'testMetadata', {
             testName: 'testName',
             type: 'image',
-            name: 'image',
             value: '.teamcity/path/to/image.png'
         });
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -61,7 +61,7 @@ describe('getTestName', function() {
 
 describe('getImagePath', function() {
     var data;
-    var imageBase;
+    var imageBase = 'base';
     var func = utils.getImagePath;
     var base = utils.imagesPath;
 
@@ -75,7 +75,6 @@ describe('getImagePath', function() {
             },
             browserId: 'chrome'
         };
-        imageBase = 'base'
     });
 
     it('should trim the suite name from spaces', function() {
@@ -120,6 +119,7 @@ describe('getImagePath', function() {
 describe('reportScreenshot', function() {
     var sandbox = sinon.sandbox.create();
     var func = utils.reportScreenshot;
+    var testName = 'testName';
 
     beforeEach(function() {
         sandbox.stub(tsm);
@@ -130,7 +130,7 @@ describe('reportScreenshot', function() {
     });
 
     it('should store artifact', function() {
-        func('path/to/image');
+        func(testName, 'path/to/image');
 
         assert.calledWithMatch(tsm.publishArtifacts, {
             path: 'path/to/image => .teamcity'
@@ -138,10 +138,11 @@ describe('reportScreenshot', function() {
     });
 
     it('should report metadata', function() {
-        func('path/to/image');
+        func(testName, 'path/to/image');
 
         assert.calledWithNew(tsm.Message);
         assert.calledWithMatch(tsm.Message, 'testMetadata', {
+            testName: 'testName',
             type: 'image',
             value: '.teamcity/path/to/image'
         });

--- a/test/utils.js
+++ b/test/utils.js
@@ -134,9 +134,7 @@ describe('reportScreenshot', function() {
     it('should store artifact', function() {
         func(testName, 'path/to/image');
 
-        assert.calledWithMatch(tsm.publishArtifacts, {
-            path: '<cwd>/path/to/image => .teamcity/path/to'
-        });
+        assert.calledWith(tsm.publishArtifacts, '<cwd>/path/to/image => .teamcity/path/to');
     });
 
     it('should report metadata', function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var assert = require('chai').assert;
 var sinon = require('sinon');
 var tsm = require('teamcity-service-messages');
@@ -123,6 +124,7 @@ describe('reportScreenshot', function() {
 
     beforeEach(function() {
         sandbox.stub(tsm);
+        sandbox.stub(path, 'resolve', path.join.bind(path, '<cwd>'));
     });
 
     afterEach(function() {
@@ -133,7 +135,7 @@ describe('reportScreenshot', function() {
         func(testName, 'path/to/image');
 
         assert.calledWithMatch(tsm.publishArtifacts, {
-            path: 'path/to/image => .teamcity'
+            path: '<cwd>/path/to/image => .teamcity/path/to'
         });
     });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -132,19 +132,20 @@ describe('reportScreenshot', function() {
     });
 
     it('should store artifact', function() {
-        func(testName, 'path/to/image');
+        func(testName, 'path/to/image.png');
 
-        assert.calledWith(tsm.publishArtifacts, '<cwd>/path/to/image => .teamcity/path/to');
+        assert.calledWith(tsm.publishArtifacts, '<cwd>/path/to/image.png => .teamcity/path/to');
     });
 
     it('should report metadata', function() {
-        func(testName, 'path/to/image');
+        func(testName, 'path/to/image.png');
 
         assert.calledWithNew(tsm.Message);
         assert.calledWithMatch(tsm.Message, 'testMetadata', {
             testName: 'testName',
             type: 'image',
-            value: '.teamcity/path/to/image'
+            name: 'image',
+            value: '.teamcity/path/to/image.png'
         });
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -140,8 +140,7 @@ describe('reportScreenshot', function() {
     it('should report metadata', function() {
         func(testName, 'path/to/image.png');
 
-        assert.calledWithNew(tsm.Message);
-        assert.calledWithMatch(tsm.Message, 'testMetadata', {
+        assert.calledWithMatch(tsm.testMetadata, {
             testName: 'testName',
             type: 'image',
             value: '.teamcity/path/to/image.png'


### PR DESCRIPTION
Test metadata is a new feature of TeamCity 2018.2, see https://confluence.jetbrains.com/display/TCD18/Reporting+Test+Metadata

This enables viewing screenshots directly in expanded test results:
<img width="1571" alt="screenshot 2018-12-13 at 13 58 21" src="https://user-images.githubusercontent.com/6651625/49940227-4135b100-fedf-11e8-8b55-e9945576f165.png">
